### PR TITLE
Fix db name usage and auth import

### DIFF
--- a/server/app/mongodb_server.py
+++ b/server/app/mongodb_server.py
@@ -11,4 +11,4 @@ client = motor.motor_asyncio.AsyncIOMotorClient(
     MONGO_URI,
     server_api=ServerApi("1")
 ) 
-db = client["Cluster0"]
+db = client[DB_NAME]

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -10,7 +10,7 @@ from fastapi import Depends
 
 from .mongodb_server import db
 from .models import PlantResponse, IdentifyRequest, Suggestion, SimilarImage, UpdateNotesRequest
-from .auth import get_current_user
+from .deps import get_current_user
 
 # Load environment variables
 load_dotenv()


### PR DESCRIPTION
## Summary
- correct dependency import in FastAPI routes
- use configured DB name when connecting to MongoDB

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68608480bbb883259b61bc0c10441e00