### PR TITLE
Support JWT from cookie

### DIFF
--- a/server/app/deps.py
+++ b/server/app/deps.py
@@ -1,13 +1,22 @@
 # server/app/deps.py
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import jwt, os
 
-oauth2_scheme = HTTPBearer()
+oauth2_scheme = HTTPBearer(auto_error=False)
 
-async def get_current_user(token: HTTPAuthorizationCredentials = Depends(oauth2_scheme)):
+async def get_current_user(request: Request):
+    """Return JWT payload from header or cookie."""
+    credentials: HTTPAuthorizationCredentials | None = await oauth2_scheme(request)
+    token = None
+    if credentials:
+        token = credentials.credentials
+    else:
+        token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(401, "Invalid auth token")
     try:
-        payload = jwt.decode(token.credentials, os.getenv("JWT_SECRET"), algorithms=["HS256"])
+        payload = jwt.decode(token, os.getenv("JWT_SECRET"), algorithms=["HS256"])
     except jwt.PyJWTError:
         raise HTTPException(401, "Invalid auth token")
     return payload  # e.g. { sub, email, exp }


### PR DESCRIPTION
## Summary
- allow `get_current_user` to read tokens from cookies when the `Authorization` header is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686098074f1c8325b0a5a41304cf9da3