### PR TITLE
Add CORS middleware configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ A full-stack plant tracker web application built with:
    npm run dev
    ```
 
-4. **Use the App**  
-   - Frontend runs at http://localhost:3000  
-   - Backend runs at http://localhost:8000  
+4. **Use the App**
+   - Frontend runs at http://localhost:8080
+   - Backend runs at http://localhost:8000
+   - Backend CORS allows requests from http://localhost:8080
    - Upload plant images, identify, and save to MongoDB.

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 import os
 from .routes import router
@@ -12,6 +13,14 @@ app.add_middleware(
     secret_key=os.getenv("SESSION_SECRET_KEY", "a-strong-fallback-secret"),
     session_cookie="session",       # optional, defaults to "session"
     max_age=86400,                  # optional, seconds until cookie expires
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:8080"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # Then include your routers:


### PR DESCRIPTION
## Summary
- add CORS middleware to FastAPI app
- document the local origin allowed by CORS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609817e2648325814f7eef22462de4