### PR TITLE
Centralize API base URL with env variable

### DIFF
--- a/flora-finder-webapp-main/src/api/api.ts
+++ b/flora-finder-webapp-main/src/api/api.ts
@@ -5,9 +5,13 @@ import {
   IdentifiedPlant,
 } from './models';
 
+// Base API URL used throughout the frontend when communicating with the backend
+// Falls back to localhost if the env variable is undefined
+export const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+
 // Base API client
 const apiClient = axios.create({
-  baseURL: 'http://localhost:8000/api',
+  baseURL: `${API_BASE}/api`,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/flora-finder-webapp-main/src/components/AuthButton.tsx
+++ b/flora-finder-webapp-main/src/components/AuthButton.tsx
@@ -1,12 +1,13 @@
 // src/components/AuthButton.tsx
 import React, { useEffect, useState } from 'react';
+import { API_BASE } from '../api/api';
 
 export default function AuthButton() {
   const [user, setUser] = useState<{ email: string } | null>(null);
 
   // On mount, try fetching the current user
   useEffect(() => {
-    fetch('/api/auth/me', { credentials: 'include' })
+    fetch(`${API_BASE}/api/auth/me`, { credentials: 'include' })
       .then(res => res.ok ? res.json() : Promise.reject())
       .then(data => setUser(data))
       .catch(() => setUser(null));
@@ -16,7 +17,7 @@ export default function AuthButton() {
     return (
       <button onClick={() => {
         // logging out just clears the cookie
-        fetch('/api/auth/logout', {
+        fetch(`${API_BASE}/api/auth/logout`, {
           method: 'POST',
           credentials: 'include'
         }).then(() => window.location.reload());
@@ -29,7 +30,7 @@ export default function AuthButton() {
   return (
     <button onClick={() => {
       // Redirect to your FastAPI Google login endpoint:
-      window.location.href = 'http://localhost:8000/api/auth/google/login';
+      window.location.href = `${API_BASE}/api/auth/google/login`;
     }}>
       Sign in with Google
     </button>

--- a/flora-finder-webapp-main/src/pages/Index.tsx
+++ b/flora-finder-webapp-main/src/pages/Index.tsx
@@ -7,7 +7,7 @@ import HistorySection from '@/components/HistorySection';
 import AuthButton from '@/components/AuthButton';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { identifyPlant, fetchPlants } from '../api/api';
+import { identifyPlant, fetchPlants, API_BASE } from '../api/api';
 import { IdentifiedPlant } from '../api/models';
 
 const Index = () => {
@@ -23,7 +23,7 @@ const Index = () => {
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch('/api/auth/me', { credentials: 'include' });
+        const res = await fetch(`${API_BASE}/api/auth/me`, { credentials: 'include' });
         if (res.ok) {
           const data = await res.json();
           console.log(data);


### PR DESCRIPTION
## Summary
- default API base URL to `REACT_APP_API_URL` environment variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686098135f60832583c465f75dcc839f