### PR TITLE
Add frontend env example and API base override

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ A full-stack plant tracker web application built with:
    ```bash
    cd server
    pip install -r requirements.txt
-   cp .env.example .env
-   # Fill in MONGODB_URI and PLANT_ID_API_KEY in .env
+   cp .env.sample .env
+   # Fill in the required environment variables in .env
    uvicorn app.main:app --reload
    ```
 
 3. **Frontend Setup**  
    ```bash
-   cd client
+   cd flora-finder-webapp-main
+   cp .env.sample .env
    npm install
    npm run dev
    ```

--- a/flora-finder-webapp-main/.env.sample
+++ b/flora-finder-webapp-main/.env.sample
@@ -1,0 +1,2 @@
+# Example environment variables for Plant Tracker frontend
+VITE_API_BASE=http://localhost:8000

--- a/flora-finder-webapp-main/src/api/api.ts
+++ b/flora-finder-webapp-main/src/api/api.ts
@@ -7,7 +7,7 @@ import {
 
 // Base API URL used throughout the frontend when communicating with the backend
 // Falls back to localhost if the env variable is undefined
-export const API_BASE = 'http://localhost:8000';
+export const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
 
 // Base API client
 const apiClient = axios.create({

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -1,0 +1,8 @@
+# Example environment variables for Plant Tracker
+MONGODB_URI=mongodb://localhost:27017
+MONGODB_DB_NAME=plant_tracker
+PLANT_ID_API_KEY=your-plant-id-api-key
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+JWT_SECRET=your-jwt-secret
+SESSION_SECRET_KEY=your-session-secret-key


### PR DESCRIPTION
## Summary
- add `.env.sample` for the frontend with API base variable
- read API base from `VITE_API_BASE` in the frontend
- document env setup for both server and frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609c13705c8325b8eea4e6ed7f9826