### PR TITLE
Fix logout deleting cookie

### DIFF
--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -126,6 +126,8 @@ async def me(user=Depends(get_current_user)):
     return { "email": user["email"], "sub": user["sub"] }
 
 @router.post("/auth/logout")
-async def logout(response: Response):
+async def logout():
+    """Clear the auth cookie so the user is fully logged out."""
+    response = JSONResponse({"detail": "Logged out"})
     response.delete_cookie("access_token")
-    return JSONResponse({"detail": "Logged out"})
+    return response


### PR DESCRIPTION
## Summary
- fix logout endpoint so response sent to client deletes the auth cookie

## Testing
- `python3 -m py_compile server/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68609d3455bc832586cd5dfcc4c7e484