### PR TITLE
Add environment-based URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,28 @@ A full-stack plant tracker web application built with:
    cd plant-tracker
    ```
 
-2. **Backend Setup**  
+2. **Backend Setup**
    ```bash
    cd server
    pip install -r requirements.txt
    cp .env.sample .env
    # Fill in the required environment variables in .env
+   # FRONTEND_URL controls where the auth flow redirects after login
+   # ALLOWED_ORIGINS is a comma separated list used for CORS
    uvicorn app.main:app --reload
    ```
 
-3. **Frontend Setup**  
+3. **Frontend Setup**
    ```bash
    cd flora-finder-webapp-main
    cp .env.sample .env
+   # Set VITE_API_BASE to your backend URL (e.g. http://localhost:8000)
    npm install
    npm run dev
    ```
 
 4. **Use the App**
-   - Frontend runs at http://localhost:8080
+   - Frontend runs at http://localhost:8080 (or the URL specified in `FRONTEND_URL`)
    - Backend runs at http://localhost:8000
-   - Backend CORS allows requests from http://localhost:8080
+   - Backend CORS allows requests from the origins defined in `ALLOWED_ORIGINS`
    - Upload plant images, identify, and save to MongoDB.

--- a/flora-finder-webapp-main/.env.sample
+++ b/flora-finder-webapp-main/.env.sample
@@ -1,2 +1,3 @@
 # Example environment variables for Plant Tracker frontend
 VITE_API_BASE=http://localhost:8000
+# Example: http://192.168.1.100:8000 when testing on a local network

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -6,3 +6,5 @@ GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 JWT_SECRET=your-jwt-secret
 SESSION_SECRET_KEY=your-session-secret-key
+FRONTEND_URL=http://localhost:8080/
+ALLOWED_ORIGINS=http://localhost:8080

--- a/server/app/auth.py
+++ b/server/app/auth.py
@@ -54,6 +54,7 @@ async def auth_callback(request: Request):
     }
     jwt_token = jwt.encode(payload, os.getenv("JWT_SECRET"), algorithm="HS256")
 
-    response = RedirectResponse(url="http://localhost:8080/")  # send user home
+    frontend_url = os.getenv("FRONTEND_URL", "http://localhost:8080/")
+    response = RedirectResponse(url=frontend_url)  # send user home
     response.set_cookie("access_token", jwt_token, httponly=True, max_age=3600)
     return response

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -29,9 +29,10 @@ app.add_middleware(
     max_age=86400,
 )
 
+origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:8080")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:8080"],
+    allow_origins=[o.strip() for o in origins.split(",")],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- make FastAPI CORS and redirect URLs configurable via env vars
- update sample env files
- document how to set VITE_API_BASE and backend variables for different environments

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6861c31a4c60832586edb84d5dacf16d