### PR TITLE
Add Heroku deployment support

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app.main:app --host=0.0.0.0 --port=${PORT:-8000} --app-dir server

--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ A full-stack plant tracker web application built with:
    - Backend runs at http://localhost:8000
    - Backend CORS allows requests from the origins defined in `ALLOWED_ORIGINS`
    - Upload plant images, identify, and save to MongoDB.
+
+## Deploying to Heroku
+
+This repository contains both the FastAPI backend and the React frontend. To
+deploy them as a single Heroku app:
+
+1. Add the Node and Python buildpacks (Node first):
+   ```bash
+   heroku buildpacks:add heroku/nodejs
+   heroku buildpacks:add heroku/python
+   ```
+2. Push the code to Heroku. The root `package.json` defines a
+   `heroku-postbuild` script which installs dependencies and builds the React
+   app. The compiled assets are served by FastAPI from the `dist/` directory.
+3. Heroku will start the backend using the root `Procfile`:
+   ```bash
+   web: uvicorn app.main:app --host=0.0.0.0 --port=$PORT --app-dir server
+   ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plant-tracker",
+  "private": true,
+  "scripts": {
+    "heroku-postbuild": "cd flora-finder-webapp-main && npm install && npm run build"
+  }
+}

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
+from fastapi.staticfiles import StaticFiles
 import os
 
 from .routes import router
@@ -41,3 +42,10 @@ app.add_middleware(
 # === Routers ===
 app.include_router(auth_router)
 app.include_router(router)
+
+# === Static Files ===
+frontend_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../flora-finder-webapp-main/dist")
+)
+if os.path.isdir(frontend_dir):
+    app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")


### PR DESCRIPTION
## Summary
- add root `Procfile` for Uvicorn
- include `heroku-postbuild` script in root `package.json`
- serve built React files from FastAPI
- document deployment steps

## Testing
- `pytest -q`
- `npm install` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_6861baed43dc832593054e0ccda5cfd2