### PR TITLE
Fix insecure API base URL

### DIFF
--- a/flora-finder-webapp-main/src/api/api.ts
+++ b/flora-finder-webapp-main/src/api/api.ts
@@ -7,7 +7,9 @@ import {
 
 // Base API URL used throughout the frontend when communicating with the backend
 // Falls back to localhost if the env variable is undefined
-export const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+export const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  '//localhost:8000'; // protocol-relative fallback to avoid mixed content
 
 // Base API client
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- avoid HTTP fallback by using protocol-relative API base

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68624e00c62c8325866aec6a318e3554