### PR TITLE
Add Google site verification

### DIFF
--- a/flora-finder-webapp-main/index.html
+++ b/flora-finder-webapp-main/index.html
@@ -6,6 +6,7 @@
     <title>flora-finder-webapp</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
+    <meta name="google-site-verification" content="tmCPXnYxIOrFBFLMuLf3C1Q3dYJPe9atmnaO0iWTw88" />
 
     <meta property="og:title" content="flora-finder-webapp" />
     <meta property="og:description" content="Lovable Generated Project" />

--- a/flora-finder-webapp-main/src/api/api.ts
+++ b/flora-finder-webapp-main/src/api/api.ts
@@ -7,7 +7,9 @@ import {
 
 // Base API URL used throughout the frontend when communicating with the backend
 // Falls back to localhost if the env variable is undefined
-export const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+export const API_BASE =
+  import.meta.env.VITE_API_BASE ||
+  '//localhost:8000'; // protocol-relative fallback to avoid mixed content
 
 // Base API client
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- embed Google verification tag in index
- ensure API uses protocol-relative fallback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68624e00c62c8325866aec6a318e3554