### PR TITLE
Add carousel for similar images

### DIFF
--- a/plant-tracker-client/src/api/api.ts
+++ b/plant-tracker-client/src/api/api.ts
@@ -60,8 +60,9 @@ export async function identifyPlant(
     watering: topSuggestion.best_watering,
     soil_type: topSuggestion.best_soil_type,
     light_condition: topSuggestion.best_light_condition,
+    similar_images: topSuggestion.similar_images,
     timestamp: new Date(resp.datetime!)
-  };  
+  };
   return newIdentification;
 }
 
@@ -92,6 +93,7 @@ export async function fetchPlants(): Promise<IdentifiedPlant[]> {
       soil_type: topSuggestion.best_soil_type,
       light_condition: topSuggestion.best_light_condition,
       url: topSuggestion.url,
+      similar_images: topSuggestion.similar_images,
       timestamp: new Date(resp.datetime!)
     };
     return newIdentification;

--- a/plant-tracker-client/src/api/models.ts
+++ b/plant-tracker-client/src/api/models.ts
@@ -57,6 +57,7 @@ export interface IdentifiedPlant {
   soil_type?: string;
   light_condition?: string;
   url?: string;
+  similar_images?: SimilarImage[];
   timestamp: Date;
 }
 

--- a/plant-tracker-client/src/components/PlantResult.tsx
+++ b/plant-tracker-client/src/components/PlantResult.tsx
@@ -1,10 +1,17 @@
 
 import React from 'react';
-import { ArrowLeft, Clock, Eye, Bookmark } from 'lucide-react';
+import { ArrowLeft, Clock, Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { IdentifiedPlant } from '../api/models';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from '@/components/ui/carousel';
 
 interface PlantResultProps {
   result: IdentifiedPlant | null;
@@ -50,13 +57,23 @@ const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory
       </div>
 
       <div className="grid md:grid-cols-2 gap-8">
-        {/* Image */}
+        {/* Image Carousel */}
         <Card className="overflow-hidden">
-          <img
-            src={result.image}
-            alt="Identified plant"
-            className="w-full h-80 object-cover"
-          />
+          <Carousel className="w-full">
+            <CarouselContent>
+              {[result.image, ...(result.similar_images?.map(img => img.url) || [])].map((src, idx) => (
+                <CarouselItem key={idx} className="flex items-center justify-center">
+                  <img
+                    src={src}
+                    alt={`Plant image ${idx}`}
+                    className="w-full h-80 object-cover"
+                  />
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious />
+            <CarouselNext />
+          </Carousel>
         </Card>
 
         {/* Results */}


### PR DESCRIPTION
## Summary
- extend `IdentifiedPlant` to expose `similar_images`
- return the similar images in API helpers
- display original and similar photos in a carousel in `PlantResult`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68630cb813bc832589bd3ff09a9e6e9e