### PR TITLE
Add geolocation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A full-stack plant tracker web application built with:
    - Backend runs at http://localhost:8000
    - Backend CORS allows requests from the origins defined in `ALLOWED_ORIGINS`
    - Upload plant images, identify, and save to MongoDB.
+   - Your browser will ask for location permission when identifying a plant so latitude and longitude can be stored with each entry.
 
 ## Deploying to Heroku
 
@@ -62,3 +63,11 @@ deploy them as a single Heroku app:
    ```bash
    web: uvicorn app.main:app --host=0.0.0.0 --port=$PORT --app-dir server
    ```
+
+## Running Tests
+
+Use pytest to run the backend test suite:
+```bash
+pytest
+```
+

--- a/plant-tracker-client/src/hooks/use-location.ts
+++ b/plant-tracker-client/src/hooks/use-location.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+export function useGeolocation() {
+  const [coords, setCoords] = useState<{ latitude: number | null; longitude: number | null }>({
+    latitude: null,
+    longitude: null,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setError('Geolocation not supported');
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setCoords({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+      },
+      (err) => {
+        setError(err.message);
+      }
+    );
+  }, []);
+
+  return { ...coords, error };
+}

--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { identifyPlant, fetchPlants, API_BASE } from '../api/api';
 import { IdentifiedPlant } from '../api/models';
+import { useGeolocation } from '@/hooks/use-location';
 import { Routes, Route, useNavigate, useLocation, Navigate } from 'react-router-dom';
 
 const Index = () => {
@@ -17,6 +18,7 @@ const Index = () => {
 
   const [currentResult, setCurrentResult] = useState<IdentifiedPlant | null>(null);
   const [identificationHistory, setIdentificationHistory] = useState<IdentifiedPlant[]>([]);
+  const { latitude, longitude } = useGeolocation();
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
@@ -70,7 +72,11 @@ const Index = () => {
 
   const handleImageCapture = async (imageData: string) => {
     try {
-      const resp: IdentifiedPlant = await identifyPlant(imageData, 53.282275, -6.116891);
+      const resp: IdentifiedPlant = await identifyPlant(
+        imageData,
+        latitude ?? undefined,
+        longitude ?? undefined
+      );
       setCurrentResult(resp);
       setIdentificationHistory(prev => [resp, ...prev]);
       navigate('/result');

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,76 @@
+import types
+import pytest
+from fastapi.testclient import TestClient
+
+from server.app import routes, main, deps
+
+class DummyCursor:
+    def __init__(self, docs):
+        self._docs = docs
+    async def to_list(self, length):
+        return self._docs[:length]
+
+class DummyPlants:
+    def __init__(self, docs=None):
+        self.docs = docs or []
+    async def insert_one(self, doc):
+        self.docs.append(doc)
+        return types.SimpleNamespace(inserted_id="1")
+    def find(self, query):
+        return DummyCursor(self.docs)
+    async def update_one(self, filter_, update):
+        matched = 1 if self.docs else 0
+        return types.SimpleNamespace(matched_count=matched)
+    async def create_index(self, *args, **kwargs):
+        pass
+
+class DummyClientAdmin:
+    async def command(self, *args, **kwargs):
+        pass
+
+class DummyClient:
+    def __init__(self):
+        self.admin = DummyClientAdmin()
+
+class DummyDB:
+    def __init__(self, docs=None):
+        self.client = DummyClient()
+        self.plants = DummyPlants(docs)
+
+@pytest.fixture
+def client(monkeypatch):
+    fake_db = DummyDB([{"_id": "abc", "user_id": "user1"}])
+    monkeypatch.setattr(routes, "db", fake_db)
+    monkeypatch.setattr(main, "db", fake_db)
+    main.app.dependency_overrides[deps.get_current_user] = lambda: {"sub": "user1", "email": "test@example.com"}
+    with TestClient(main.app) as c:
+        yield c
+    main.app.dependency_overrides.clear()
+
+def test_auth_me(client):
+    resp = client.get("/api/auth/me")
+    assert resp.status_code == 200
+    assert resp.json() == {"email": "test@example.com", "sub": "user1"}
+
+def test_logout(client):
+    resp = client.post("/api/auth/logout")
+    assert resp.status_code == 200
+    assert resp.json()["detail"] == "Logged out"
+    assert "access_token=" in resp.headers.get("set-cookie", "")
+
+def test_get_plants(client):
+    resp = client.get("/api/my-plants")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+def test_update_notes_not_found(client, monkeypatch):
+    # patch db to have no docs so update_one returns matched_count=0
+    empty_db = DummyDB([])
+    monkeypatch.setattr(routes, "db", empty_db)
+    monkeypatch.setattr(main, "db", empty_db)
+    with TestClient(main.app) as c:
+        main.app.dependency_overrides[deps.get_current_user] = lambda: {"sub": "user1", "email": "test@example.com"}
+        resp = c.put("/api/update-plant-notes", json={"id": "507f1f77bcf86cd799439011", "notes": "hi"})
+    main.app.dependency_overrides.clear()
+    assert resp.status_code == 404
+


### PR DESCRIPTION
## Summary
- request browser location using new `useGeolocation` hook
- send latitude and longitude when identifying plants
- document permission in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -r server/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68650aa69344832591c9f794cbbcb0ea