### PR TITLE
Add plant notes support

### DIFF
--- a/plant-tracker-client/src/api/api.ts
+++ b/plant-tracker-client/src/api/api.ts
@@ -51,7 +51,7 @@ export async function identifyPlant(
   const topSuggestion = resp.suggestions[0];
 
   const newIdentification: IdentifiedPlant = {
-    id: topSuggestion.id || Date.now().toString(), // Use the ID from the suggestion if available
+    id: resp.id || topSuggestion.id || Date.now().toString(),
     image: resp.image_data!,
     plantName: topSuggestion.common_names?.[0] || topSuggestion.name, // Prefer common name, fallback to scientific
     scientificName: topSuggestion.name, // Always store the scientific name
@@ -61,7 +61,8 @@ export async function identifyPlant(
     soil_type: topSuggestion.best_soil_type,
     light_condition: topSuggestion.best_light_condition,
     similar_images: topSuggestion.similar_images,
-    timestamp: new Date(resp.datetime!)
+    timestamp: new Date(resp.datetime!),
+    notes: resp.notes
   };
   return newIdentification;
 }
@@ -83,7 +84,7 @@ export async function fetchPlants(): Promise<IdentifiedPlant[]> {
     const topSuggestion = resp.suggestions[0];
 
     const newIdentification: IdentifiedPlant = {
-      id: topSuggestion.id || resp.datetime || Date.now().toString(), // Use suggestion ID, fallback to datetime or now
+      id: resp.id || topSuggestion.id || resp.datetime || Date.now().toString(),
       image: resp.image_data!,
       plantName: topSuggestion.common_names?.[0] || topSuggestion.name,
       scientificName: topSuggestion.name,
@@ -94,7 +95,8 @@ export async function fetchPlants(): Promise<IdentifiedPlant[]> {
       light_condition: topSuggestion.best_light_condition,
       url: topSuggestion.url,
       similar_images: topSuggestion.similar_images,
-      timestamp: new Date(resp.datetime!)
+      timestamp: new Date(resp.datetime!),
+      notes: resp.notes
     };
     return newIdentification;
   }).filter((plant): plant is IdentifiedPlant => plant !== null); // Filter out any nulls

--- a/plant-tracker-client/src/api/models.ts
+++ b/plant-tracker-client/src/api/models.ts
@@ -30,6 +30,7 @@ export interface Suggestion {
  * Represents the raw response from the `identifyPlant` API endpoint.
  */
 export interface ApiPlantResponse {
+  id?: string;
   user_id?: string;
   access_token?: string;
   is_plant_boolean: boolean;
@@ -59,6 +60,7 @@ export interface IdentifiedPlant {
   url?: string;
   similar_images?: SimilarImage[];
   timestamp: Date;
+  notes?: string;
 }
 
 /**

--- a/plant-tracker-client/src/components/PlantResult.tsx
+++ b/plant-tracker-client/src/components/PlantResult.tsx
@@ -5,6 +5,8 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { IdentifiedPlant } from '../api/models';
+import { updatePlantNotes } from '@/api/api';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Carousel,
   CarouselContent,
@@ -20,6 +22,20 @@ interface PlantResultProps {
 }
 
 const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory }) => {
+  const [notes, setNotes] = React.useState(result?.notes || '');
+  const [saving, setSaving] = React.useState(false);
+
+  const handleSaveNotes = async () => {
+    if (!result) return;
+    setSaving(true);
+    try {
+      await updatePlantNotes({ id: result.id, notes });
+    } catch {
+      alert('Failed to save notes');
+    } finally {
+      setSaving(false);
+    }
+  };
   if (!result) {
     return (
       <Card className="max-w-2xl mx-auto p-8 text-center">
@@ -144,6 +160,19 @@ const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory
             <p className="text-green-700">{result.soil_type}</p>
           </div>
         </div>
+      </Card>
+
+      {/* Notes */}
+      <Card className="p-6 space-y-4">
+        <h4 className="text-xl font-semibold text-gray-800">Your Notes</h4>
+        <Textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Add notes..."
+        />
+        <Button onClick={handleSaveNotes} disabled={saving}>
+          {saving ? 'Saving...' : 'Save Notes'}
+        </Button>
       </Card>
     </div>
   );

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -31,6 +31,7 @@ class Suggestion(BaseModel):
     similar_images: Optional[List[SimilarImage]] = []
 
 class PlantResponse(BaseModel):
+    id: Optional[str] = None
     user_id: Optional[str] = None
     access_token: Optional[str] = None
     is_plant_boolean: bool

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -91,7 +91,8 @@ async def identify_plant(request: IdentifyRequest, user=Depends(get_current_user
 
     # Immediately save to MongoDB
     doc = jsonable_encoder(response)
-    await db.plants.insert_one(doc)
+    result = await db.plants.insert_one(doc)
+    response.id = str(result.inserted_id)
 
     return response
 
@@ -112,7 +113,11 @@ async def update_plant_notes(request: UpdateNotesRequest):
 async def get_plants(user=Depends(get_current_user)):
     # with the index in place this is now a quick lookup
     docs = await db.plants.find({"user_id": user["sub"]}).to_list(length=20)
-    return [PlantResponse(**doc) for doc in docs]
+    results = []
+    for doc in docs:
+        doc["id"] = str(doc.get("_id"))
+        results.append(PlantResponse(**doc))
+    return results
 
 @router.get("/auth/me")
 async def me(user=Depends(get_current_user)):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -61,7 +61,10 @@ def test_logout(client):
 def test_get_plants(client):
     resp = client.get("/api/my-plants")
     assert resp.status_code == 200
-    assert isinstance(resp.json(), list)
+    data = resp.json()
+    assert isinstance(data, list)
+    if data:
+        assert "id" in data[0]
 
 def test_update_notes_not_found(client, monkeypatch):
     # patch db to have no docs so update_one returns matched_count=0


### PR DESCRIPTION
## Summary
- add `id` field to PlantResponse model
- return inserted document ID and include it when fetching plants
- expose notes in API responses and models
- allow saving notes in PlantResult UI
- test that plant entries include an id

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6865b665c9108325a0481baf51a45d3a