### PR TITLE
Add timestamp field on MongoDB saves

### DIFF
--- a/server/app/models.py
+++ b/server/app/models.py
@@ -34,15 +34,16 @@ class PlantResponse(BaseModel):
     id: Optional[str] = None
     user_id: Optional[str] = None
     access_token: Optional[str] = None
-    is_plant_boolean: bool
-    is_plant_probability: float
-    suggestions: List[Suggestion]
+    is_plant_boolean: Optional[bool] = None
+    is_plant_probability: Optional[float] = None
+    suggestions: Optional[List[Suggestion]] = []
     notes: Optional[str] = None
     datetime: Optional[str] = None
     latitude: Optional[float] = None
     longitude: Optional[float] = None
     image_data: Optional[str] = None
     images: Optional[List[str]] = None
+    _ts: Optional[int] = None
 
 class UpdateNotesRequest(BaseModel):
     id: str

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -1,5 +1,6 @@
 import os
 import base64
+import time
 from fastapi import Depends, APIRouter, HTTPException
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
@@ -89,7 +90,8 @@ async def identify_plant(request: IdentifyRequest, user=Depends(get_current_user
         latitude=identification.input.latitude,
         longitude=identification.input.longitude,
         image_data=request.images[0] if request.images else None,
-        images=request.images
+        images=request.images,
+        _ts=int(time.time())
     )
 
     # Immediately save to MongoDB
@@ -105,7 +107,7 @@ async def update_plant_notes(request: UpdateNotesRequest):
         raise HTTPException(status_code=400, detail="Invalid plant ID")
     result = await db.plants.update_one(
         {"_id": ObjectId(request.id)},
-        {"$set": {"notes": request.notes}}
+        {"$set": {"notes": request.notes, "_ts": int(time.time())}}
     )
     if result.matched_count == 0:
         raise HTTPException(status_code=404, detail="Plant not found")


### PR DESCRIPTION
## Summary
- add optional `_ts` Unix timestamp to `PlantResponse`
- record `_ts` when inserting or updating plant documents
- make required fields in `PlantResponse` optional so partial docs don't error

## Testing
- `PLANT_ID_API_KEY=fake pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ca4c09e083258d997bc95a43a0d6