### PR TITLE
Display taxonomy for plant records

### DIFF
--- a/plant-tracker-client/src/api/api.ts
+++ b/plant-tracker-client/src/api/api.ts
@@ -65,6 +65,7 @@ export async function identifyPlant(
     watering: topSuggestion.best_watering,
     soil_type: topSuggestion.best_soil_type,
     light_condition: topSuggestion.best_light_condition,
+    taxonomy: topSuggestion.taxonomy as Record<string, string> | undefined,
     similar_images: topSuggestion.similar_images,
     timestamp: new Date(resp.datetime!),
     notes: resp.notes
@@ -96,13 +97,14 @@ export async function fetchPlants(): Promise<IdentifiedPlant[]> {
       confidence: Math.round(topSuggestion.probability * 100),
       description: topSuggestion.description,
       watering: topSuggestion.best_watering,
-      soil_type: topSuggestion.best_soil_type,
-      light_condition: topSuggestion.best_light_condition,
-      url: topSuggestion.url,
-      similar_images: topSuggestion.similar_images,
-      timestamp: new Date(resp.datetime!),
-      notes: resp.notes
-    };
+    soil_type: topSuggestion.best_soil_type,
+    light_condition: topSuggestion.best_light_condition,
+    taxonomy: topSuggestion.taxonomy as Record<string, string> | undefined,
+    url: topSuggestion.url,
+    similar_images: topSuggestion.similar_images,
+    timestamp: new Date(resp.datetime!),
+    notes: resp.notes
+  };
     return newIdentification;
   }).filter((plant): plant is IdentifiedPlant => plant !== null); // Filter out any nulls
 

--- a/plant-tracker-client/src/api/models.ts
+++ b/plant-tracker-client/src/api/models.ts
@@ -59,6 +59,7 @@ export interface IdentifiedPlant {
   soil_type?: string;
   light_condition?: string;
   url?: string;
+  taxonomy?: Record<string, string>;
   similar_images?: SimilarImage[];
   timestamp: Date;
   notes?: string;

--- a/plant-tracker-client/src/components/PlantResult.tsx
+++ b/plant-tracker-client/src/components/PlantResult.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { IdentifiedPlant } from '../api/models';
 import { updatePlantNotes } from '@/api/api';
 import { Textarea } from '@/components/ui/textarea';
+import TaxonomyChart from './TaxonomyChart';
 import {
   Carousel,
   CarouselContent,
@@ -154,6 +155,14 @@ const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory
           </div>
         </Card>
       </div>
+
+      {/* Taxonomy */}
+      {result.taxonomy && (
+        <Card className="p-6 space-y-4">
+          <h4 className="text-xl font-semibold text-gray-800">Taxonomy</h4>
+          <TaxonomyChart taxonomy={result.taxonomy} />
+        </Card>
+      )}
 
       {/* Notes */}
       <Card className="p-6 space-y-4">

--- a/plant-tracker-client/src/components/TaxonomyChart.tsx
+++ b/plant-tracker-client/src/components/TaxonomyChart.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+interface TaxonomyChartProps {
+  taxonomy: Record<string, string>;
+}
+
+const LEVEL_ORDER = [
+  'kingdom',
+  'phylum',
+  'class',
+  'order',
+  'family',
+  'genus',
+  'species',
+];
+
+const TaxonomyChart: React.FC<TaxonomyChartProps> = ({ taxonomy }) => {
+  const entries = LEVEL_ORDER
+    .filter((level) => taxonomy[level])
+    .map((level) => ({ level, value: taxonomy[level] }));
+
+  if (entries.length === 0) return null;
+
+  return (
+    <ul className="relative border-l-2 border-green-600 pl-4 space-y-2">
+      {entries.map(({ level, value }) => (
+        <li key={level} className="relative pl-2">
+          <span className="absolute -left-3 top-2 w-2 h-2 bg-green-600 rounded-full"></span>
+          <span className="capitalize font-semibold mr-1">{level}:</span>
+          <span className="italic text-gray-700">{value}</span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default TaxonomyChart;


### PR DESCRIPTION
## Summary
- extend `IdentifiedPlant` model with taxonomy field
- surface taxonomy in API helpers
- create `TaxonomyChart` component for a simple vertical tree
- show taxonomy on the plant details page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687978cd6d5883258788b12a332c6d4e