### PR TITLE
Replace alerts with toast notifications

### DIFF
--- a/plant-tracker-client/src/api/api.ts
+++ b/plant-tracker-client/src/api/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { toast } from '@/hooks/use-toast';
 import {
   ApiPlantResponse,
   UpdateNotesRequest,
@@ -49,7 +50,7 @@ export async function identifyPlant(
   const resp = response.data
   // It's good practice to check if suggestions exist
   if (!resp.suggestions || resp.suggestions.length === 0) {
-    alert('Could not identify the plant from the image.');
+    toast({ description: 'Could not identify the plant from the image.' });
     return;
   }
 

--- a/plant-tracker-client/src/components/ImageUpload.tsx
+++ b/plant-tracker-client/src/components/ImageUpload.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState } from 'react';
 import { Upload, X, Image } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { toast } from '@/hooks/use-toast';
 
 interface ImageUploadProps {
   onUpload: (images: string[]) => void;
@@ -16,11 +17,11 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack }) => {
 
   const handleFile = (file: File) => {
     if (previews.length >= 5) {
-      alert('You can upload up to 5 images.');
+      toast({ description: 'You can upload up to 5 images.' });
       return;
     }
     if (!file.type.startsWith('image/')) {
-      alert('Please select an image file');
+      toast({ description: 'Please select an image file' });
       return;
     }
 

--- a/plant-tracker-client/src/components/PlantCamera.tsx
+++ b/plant-tracker-client/src/components/PlantCamera.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import { Camera, X, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { toast } from '@/hooks/use-toast';
 
 interface PlantCameraProps {
   onCapture: (images: string[]) => void;
@@ -55,7 +56,7 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack }) => {
   const capturePhoto = () => {
     if (!videoRef.current || !canvasRef.current) return;
     if (captures.length >= 5) {
-      alert('You can capture up to 5 photos.');
+      toast({ description: 'You can capture up to 5 photos.' });
       return;
     }
 

--- a/plant-tracker-client/src/components/PlantResult.tsx
+++ b/plant-tracker-client/src/components/PlantResult.tsx
@@ -6,6 +6,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { IdentifiedPlant } from '../api/models';
 import { updatePlantNotes } from '@/api/api';
+import { toast } from '@/hooks/use-toast';
 import { Textarea } from '@/components/ui/textarea';
 import {
   Carousel,
@@ -42,7 +43,7 @@ const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory
       setShowSaved(true);
       setTimeout(() => setShowSaved(false), 2000);
     } catch {
-      alert('Failed to save notes');
+      toast({ description: 'Failed to save notes' });
     } finally {
       setSaving(false);
     }

--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import { identifyPlant, fetchPlants, API_BASE } from '../api/api';
 import { IdentifiedPlant } from '../api/models';
 import { useGeolocation } from '@/hooks/use-location';
 import { Routes, Route, useNavigate, useLocation, Navigate } from 'react-router-dom';
+import { toast } from '@/hooks/use-toast';
 
 const Index = () => {
   const [user, setUser] = useState<{ email: string } | null>(null);
@@ -63,7 +64,7 @@ const Index = () => {
         setIdentificationHistory(historyData);
       } catch (error) {
         console.error('Failed to fetch identification history:', error);
-        alert('Could not load previous identifications.');
+        toast({ description: 'Could not load previous identifications.' });
       } finally {
         setIsLoading(false);
       }
@@ -80,11 +81,11 @@ const Index = () => {
       setCurrentResult(resp);
       setIdentificationHistory(prev => [resp, ...prev]);
       navigate('/result');
-    } catch (e) {
-      console.error(e);
-      alert('Failed to identify plant. Please try again.');
-    }
-  };
+      } catch (e) {
+        console.error(e);
+        toast({ description: 'Failed to identify plant.' });
+      }
+    };
 
   const handleImageUpload = handleImageCapture;
 


### PR DESCRIPTION
## Summary
- swap alert dialogs for toasts throughout the frontend
- show toast when identification fails or history cannot be loaded
- notify via toast on image upload/camera limits and save errors
- call toast from API when no suggestions are returned

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type` etc.)*
- `pytest -q` *(fails: `PLANT_ID_API_KEY not set in environment variables`)*

------
https://chatgpt.com/codex/tasks/task_e_6879c753f48c832589e532ef895c8be2