### PR TITLE
Add identifying spinner

### DIFF
--- a/plant-tracker-client/src/components/ImageUpload.tsx
+++ b/plant-tracker-client/src/components/ImageUpload.tsx
@@ -7,9 +7,10 @@ import { Card } from '@/components/ui/card';
 interface ImageUploadProps {
   onUpload: (images: string[]) => void;
   onBack: () => void;
+  identifying?: boolean;
 }
 
-const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack }) => {
+const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
   const [previews, setPreviews] = useState<string[]>([]);
@@ -76,7 +77,15 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack }) => {
   };
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
+    <div className="relative max-w-4xl mx-auto space-y-6">
+      {identifying && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="flex items-center space-x-2 text-white">
+            <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            <span>Identifying...</span>
+          </div>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <Button onClick={onBack} variant="outline" size="lg">
           <X className="mr-2 h-4 w-4" />

--- a/plant-tracker-client/src/components/PlantCamera.tsx
+++ b/plant-tracker-client/src/components/PlantCamera.tsx
@@ -7,9 +7,10 @@ import { Card } from '@/components/ui/card';
 interface PlantCameraProps {
   onCapture: (images: string[]) => void;
   onBack: () => void;
+  identifying?: boolean;
 }
 
-const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack }) => {
+const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifying }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [stream, setStream] = useState<MediaStream | null>(null);
@@ -91,7 +92,15 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack }) => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
+    <div className="relative max-w-4xl mx-auto space-y-6">
+      {identifying && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="flex items-center space-x-2 text-white">
+            <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            <span>Identifying...</span>
+          </div>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <Button onClick={onBack} variant="outline" size="lg">
           <X className="mr-2 h-4 w-4" />

--- a/plant-tracker-client/src/components/PlantResult.tsx
+++ b/plant-tracker-client/src/components/PlantResult.tsx
@@ -19,9 +19,10 @@ interface PlantResultProps {
   result: IdentifiedPlant | null;
   onBack: () => void;
   onViewHistory: () => void;
+  identifying?: boolean;
 }
 
-const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory }) => {
+const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory, identifying }) => {
   const [notes, setNotes] = React.useState(result?.notes || '');
   const [saving, setSaving] = React.useState(false);
   const [editing, setEditing] = React.useState(!result?.notes);
@@ -62,7 +63,15 @@ const PlantResult: React.FC<PlantResultProps> = ({ result, onBack, onViewHistory
                           result.confidence >= 70 ? 'bg-yellow-500' : 'bg-red-500';
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
+    <div className="relative max-w-4xl mx-auto space-y-6">
+      {identifying && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="flex items-center space-x-2 text-white">
+            <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            <span>Identifying...</span>
+          </div>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <Button onClick={onBack} variant="outline" size="lg">
           <ArrowLeft className="mr-2 h-4 w-4" />

--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -20,6 +20,7 @@ const Index = () => {
   const [identificationHistory, setIdentificationHistory] = useState<IdentifiedPlant[]>([]);
   const { latitude, longitude } = useGeolocation();
   const [isLoading, setIsLoading] = useState(true);
+  const [identifying, setIdentifying] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -71,6 +72,7 @@ const Index = () => {
   }, [user]);
 
   const handleImageCapture = async (images: string[]) => {
+    setIdentifying(true);
     try {
       const resp: IdentifiedPlant = await identifyPlant(
         images,
@@ -83,6 +85,8 @@ const Index = () => {
     } catch (e) {
       console.error(e);
       alert('Failed to identify plant. Please try again.');
+    } finally {
+      setIdentifying(false);
     }
   };
 
@@ -200,17 +204,18 @@ const Index = () => {
           <Route path="/" element={<Home />} />
           <Route
             path="/camera"
-            element={<PlantCamera onCapture={handleImageCapture} onBack={() => navigate('/')} />}
+            element={<PlantCamera identifying={identifying} onCapture={handleImageCapture} onBack={() => navigate('/')} />}
           />
           <Route
             path="/upload"
-            element={<ImageUpload onUpload={handleImageUpload} onBack={() => navigate('/')} />}
+            element={<ImageUpload identifying={identifying} onUpload={handleImageUpload} onBack={() => navigate('/')} />}
           />
           <Route
             path="/result"
             element={
               <PlantResult
                 result={currentResult}
+                identifying={identifying}
                 onBack={() => navigate('/')}
                 onViewHistory={() => navigate('/history')}
               />


### PR DESCRIPTION
## Summary
- track `identifying` state while calling `identifyPlant`
- show overlay spinner on capture/upload/result screens

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type`, `@typescript-eslint/no-require-imports`)*
- `pytest` *(fails: `PLANT_ID_API_KEY not set in environment variables`)*

------
https://chatgpt.com/codex/tasks/task_e_6879c71fcba88325bbea9dfb3fe7c5fd