### PR TITLE
Add theme support

### DIFF
--- a/plant-tracker-client/src/App.tsx
+++ b/plant-tracker-client/src/App.tsx
@@ -3,22 +3,41 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { ThemeProvider, useTheme } from "next-themes";
+import { useEffect } from "react";
 import Index from "./pages/Index";
 
 const queryClient = new QueryClient();
 
+const BodyClassUpdater = () => {
+  const { resolvedTheme } = useTheme();
+
+  useEffect(() => {
+    if (resolvedTheme === "dark") {
+      document.body.classList.add("dark");
+    } else {
+      document.body.classList.remove("dark");
+    }
+  }, [resolvedTheme]);
+
+  return null;
+};
+
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/*" element={<Index />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <BodyClassUpdater />
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/*" element={<Index />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 export default App;

--- a/plant-tracker-client/src/components/ThemeToggle.tsx
+++ b/plant-tracker-client/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+const ThemeToggle = () => {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+    >
+      {resolvedTheme === "dark" ? (
+        <Sun className="h-5 w-5" />
+      ) : (
+        <Moon className="h-5 w-5" />
+      )}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};
+
+export default ThemeToggle;

--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import ImageUpload from '@/components/ImageUpload';
 import PlantResult from '@/components/PlantResult';
 import HistorySection from '@/components/HistorySection';
 import AuthButton from '@/components/AuthButton';
+import ThemeToggle from '@/components/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { identifyPlant, fetchPlants, API_BASE } from '../api/api';
@@ -109,7 +110,8 @@ const Index = () => {
         <p className="text-lg text-gray-600 max-w-xl">
           Sign in with Google to identify plants from photos and keep a history of your discoveries.
         </p>
-        <div>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
           <AuthButton />
         </div>
       </div>
@@ -133,7 +135,10 @@ const Index = () => {
             <Leaf className="h-8 w-8 text-green-600 mr-2" />
             <h1 className="text-4xl font-bold text-gray-800">Plant Tracker</h1>
           </div>
-          <AuthButton />
+          <div className="flex items-center gap-2">
+            <ThemeToggle />
+            <AuthButton />
+          </div>
         </div>
 
         <div className="space-y-6 md:space-y-8">


### PR DESCRIPTION
## Summary
- add a `ThemeProvider` in `App.tsx` and sync the dark class to `<body>`
- create a reusable `ThemeToggle` component
- show the toggle beside the auth button on the sign-in screen and home header

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type`, `@typescript-eslint/no-require-imports`)*
- `pytest -q` *(fails: `PLANT_ID_API_KEY not set in environment variables`)*

------
https://chatgpt.com/codex/tasks/task_e_6879c75c8c2883259f299cb10aa2cf1e