### PR TITLE
Fix spinner lingering on failed identification

### DIFF
--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -90,13 +90,14 @@ const Index = () => {
 
       setCurrentResult(resp);
       setIdentificationHistory(prev => [resp, ...prev]);
-      setIdentifying(false);
       navigate('/result');
-      } catch (e) {
-        console.error(e);
-        toast({ description: 'Failed to identify plant.' });
-      }
-    };
+    } catch (e) {
+      console.error(e);
+      toast({ description: 'Failed to identify plant.' });
+    } finally {
+      setIdentifying(false);
+    }
+  };
 
   const handleImageUpload = handleImageCapture;
 


### PR DESCRIPTION
## Summary
- stop identifying spinner when the request fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aad4e3ebc8325b39365886814c508