### PR TITLE
Add organ selection support

### DIFF
--- a/plant-tracker-client/src/api/api.ts
+++ b/plant-tracker-client/src/api/api.ts
@@ -34,17 +34,21 @@ export async function identifyPlant(
   longitude?: number,
   userId?: string,
   threshold?: number,
+  organs?: string[],
 ): Promise<IdentifiedPlant> {
   const payload: Partial<ApiPlantResponse> = {
     image_data,
     latitude,
-    longitude
+    longitude,
   };
   if (userId) payload.user_id = userId;
   if (threshold) {
     payload.threshold = threshold;
   } else {
     payload.threshold = 0.01;
+  }
+  if (organs) {
+    payload.organs = organs;
   }
   const response = await apiClient.post<ApiPlantResponse>('/identify-plant', payload);
   const resp = response.data

--- a/plant-tracker-client/src/api/models.ts
+++ b/plant-tracker-client/src/api/models.ts
@@ -40,7 +40,8 @@ export interface ApiPlantResponse {
   datetime?: string;
   latitude?: number;
   longitude?: number;
-  image_data?: string[]; 
+  image_data?: string[];
+  organs?: string[];
   threshold?: number;
 }
 

--- a/plant-tracker-client/src/components/ImageUpload.tsx
+++ b/plant-tracker-client/src/components/ImageUpload.tsx
@@ -3,10 +3,17 @@ import React, { useRef, useState } from 'react';
 import { Upload, X, Image } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { toast } from '@/hooks/use-toast';
 
 interface ImageUploadProps {
-  onUpload: (images: string[]) => void;
+  onUpload: (images: { image: string; organ: string }[]) => void;
   onBack: () => void;
   identifying?: boolean;
 }
@@ -14,7 +21,7 @@ interface ImageUploadProps {
 const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
-  const [previews, setPreviews] = useState<string[]>([]);
+  const [previews, setPreviews] = useState<{ image: string; organ: string }[]>([]);
 
   const handleFile = (file: File) => {
     if (previews.length >= 5) {
@@ -29,7 +36,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying
     const reader = new FileReader();
     reader.onload = (e) => {
       const imageData = e.target?.result as string;
-      setPreviews(prev => [...prev, imageData]);
+      setPreviews(prev => [...prev, { image: imageData, organ: 'auto' }]);
     };
     reader.readAsDataURL(file);
   };
@@ -147,20 +154,33 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying
           <div className="space-y-6">
             <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {previews.map((p, idx) => (
-                <div key={idx} className="relative">
+                <div key={idx} className="relative space-y-2">
                   <img
-                    src={p}
+                    src={p.image}
                     alt={`preview-${idx}`}
                     className="w-full h-40 object-cover rounded-lg"
                   />
-                  <Button
-                    onClick={() => clearPreview(idx)}
-                    variant="outline"
-                    size="sm"
-                    className="absolute top-1 right-1 bg-white"
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
+                  <div className="flex items-center space-x-2">
+                    <Select value={p.organ} onValueChange={val => setPreviews(prev => prev.map((img,i)=> i===idx ? { ...img, organ: val } : img))}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="leaf">leaf</SelectItem>
+                        <SelectItem value="flower">flower</SelectItem>
+                        <SelectItem value="fruit">fruit</SelectItem>
+                        <SelectItem value="bark">bark</SelectItem>
+                        <SelectItem value="auto">auto</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      onClick={() => clearPreview(idx)}
+                      variant="outline"
+                      size="sm"
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
                 </div>
               ))}
               {previews.length < 5 && (

--- a/plant-tracker-client/src/components/PlantCamera.tsx
+++ b/plant-tracker-client/src/components/PlantCamera.tsx
@@ -3,10 +3,17 @@ import React, { useRef, useState, useEffect } from 'react';
 import { Camera, X, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { toast } from '@/hooks/use-toast';
 
 interface PlantCameraProps {
-  onCapture: (images: string[]) => void;
+  onCapture: (images: { image: string; organ: string }[]) => void;
   onBack: () => void;
   identifying?: boolean;
 }
@@ -18,7 +25,7 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [facingMode, setFacingMode] = useState<'user' | 'environment'>('environment');
-  const [captures, setCaptures] = useState<string[]>([]);
+  const [captures, setCaptures] = useState<{ image: string; organ: string }[]>([]);
 
   useEffect(() => {
     startCamera();
@@ -72,7 +79,7 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
     context.drawImage(video, 0, 0);
 
     const imageData = canvas.toDataURL('image/jpeg', 0.8);
-    setCaptures(prev => [...prev, imageData]);
+    setCaptures(prev => [...prev, { image: imageData, organ: 'auto' }]);
   };
 
   const switchCamera = () => {
@@ -150,17 +157,30 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
       {captures.length > 0 && (
         <div className="space-y-4">
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-              {captures.map((img, idx) => (
-                <div key={idx} className="relative">
-                <img src={img} alt={`capture-${idx}`} className="w-full h-32 object-cover rounded-lg" />
-                <Button
-                  onClick={() => setCaptures(c => c.filter((_, i) => i !== idx))}
-                  variant="outline"
-                  size="sm"
-                  className="absolute top-1 right-1 bg-white"
-                >
-                  <X className="h-3 w-3" />
-                </Button>
+              {captures.map((cap, idx) => (
+                <div key={idx} className="relative space-y-2">
+                <img src={cap.image} alt={`capture-${idx}`} className="w-full h-32 object-cover rounded-lg" />
+                <div className="flex items-center space-x-2">
+                  <Select value={cap.organ} onValueChange={val => setCaptures(c => c.map((p,i)=> i===idx ? { ...p, organ: val } : p))}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="leaf">leaf</SelectItem>
+                      <SelectItem value="flower">flower</SelectItem>
+                      <SelectItem value="fruit">fruit</SelectItem>
+                      <SelectItem value="bark">bark</SelectItem>
+                      <SelectItem value="auto">auto</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    onClick={() => setCaptures(c => c.filter((_, i) => i !== idx))}
+                    variant="outline"
+                    size="sm"
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
                 </div>
               ))}
             </div>

--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -72,13 +72,16 @@ const Index = () => {
     })();
   }, [user]);
 
-  const handleImageCapture = async (images: string[]) => {
+  const handleImageCapture = async (images: { image: string; organ: string }[]) => {
     setIdentifying(true);
     try {
       const resp = await identifyPlant(
-        images,
+        images.map(i => i.image),
         latitude ?? undefined,
-        longitude ?? undefined
+        longitude ?? undefined,
+        undefined,
+        undefined,
+        images.map(i => i.organ)
       );
 
       if (!resp) {

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1,16 +1,20 @@
 from pydantic import BaseModel, HttpUrl
 from typing import List, Optional, Dict, Any
 
+
 # --- Pydantic Models ---
 class IdentifyRequest(BaseModel):
     user_id: Optional[str] = None
     image_data: List[str]  # up to 5 base64-encoded images
     latitude: float
     longitude: float
+    organs: Optional[List[str]] = None
+
 
 class SimilarImage(BaseModel):
     url: HttpUrl
     similarity: float
+
 
 class Suggestion(BaseModel):
     id: str
@@ -30,6 +34,7 @@ class Suggestion(BaseModel):
     best_watering: Optional[str] = None
     similar_images: Optional[List[SimilarImage]] = []
 
+
 class PlantResponse(BaseModel):
     id: Optional[str] = None
     user_id: Optional[str] = None
@@ -42,7 +47,9 @@ class PlantResponse(BaseModel):
     latitude: Optional[float] = None
     longitude: Optional[float] = None
     image_data: Optional[List[str]] = None
+    organs: Optional[List[str]] = None
     _ts: Optional[int] = None
+
 
 class UpdateNotesRequest(BaseModel):
     id: str

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -9,7 +9,13 @@ from bson import ObjectId
 from kindwise import PlantApi, PlantIdentification, ClassificationLevel
 
 from .mongodb_server import db
-from .models import PlantResponse, IdentifyRequest, Suggestion, SimilarImage, UpdateNotesRequest
+from .models import (
+    PlantResponse,
+    IdentifyRequest,
+    Suggestion,
+    SimilarImage,
+    UpdateNotesRequest,
+)
 from .deps import get_current_user
 
 router = APIRouter(prefix="/api")
@@ -20,35 +26,51 @@ if not api_key:
     raise RuntimeError("PLANT_ID_API_KEY not set in environment variables")
 plant_client = PlantApi(api_key=api_key)
 
+
 @router.post("/identify-plant")
 async def identify_plant(request: IdentifyRequest, user=Depends(get_current_user)):
     """Identify a plant from one or more base64-encoded image strings."""
     try:
         # Decode each base64 string to raw bytes
-        b64_images = [img.split(",", 1)[1] if "," in img else img for img in request.image_data]
+        b64_images = [
+            img.split(",", 1)[1] if "," in img else img for img in request.image_data
+        ]
         img_bytes_list = [base64.b64decode(b64) for b64 in b64_images]
         details_to_return = [
-            'common_names', 'url', 'description', 'synonyms', 'edible_parts',
-            'propagation_methods', 'watering', 'best_watering', 'taxonomy',
-            'best_light_condition', 'best_soil_type', 'cultural_significance', 'image'
+            "common_names",
+            "url",
+            "description",
+            "synonyms",
+            "edible_parts",
+            "propagation_methods",
+            "watering",
+            "best_watering",
+            "taxonomy",
+            "best_light_condition",
+            "best_soil_type",
+            "cultural_significance",
+            "image",
         ]
         # Pass the raw bytes list to the client
         identification: PlantIdentification = plant_client.identify(
             img_bytes_list,
             details=details_to_return,
+            organs=request.organs,
             latitude_longitude=(request.latitude, request.longitude),
-            language=['en'],
-            classification_level=ClassificationLevel.ALL
+            language=["en"],
+            classification_level=ClassificationLevel.ALL,
         )
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Identification failed: {e}")
 
-    if (identification.status.name != 'COMPLETED' or
-        not identification.result or
-        not identification.result.classification):
+    if (
+        identification.status.name != "COMPLETED"
+        or not identification.result
+        or not identification.result.classification
+    ):
         raise HTTPException(
             status_code=500,
-            detail="Identification incomplete or missing classification"
+            detail="Identification incomplete or missing classification",
         )
 
     suggestions: List[Suggestion] = []
@@ -57,27 +79,31 @@ async def identify_plant(request: IdentifyRequest, user=Depends(get_current_user
         #     continue
         details = s.details
         desc = None
-        if details.get('description'):
-            desc = details['description'].get('value')
-        suggestions.append(Suggestion(
-            id=s.id,
-            name=s.name.title(),
-            probability=s.probability,
-            common_names=[c.title() for c in details.get('common_names')],
-            taxonomy=details.get('taxonomy'),
-            url=details.get('url'),
-            description=desc,
-            synonyms=details.get('synonyms'),
-            edible_parts=details.get('edible_parts'),
-            watering=details.get('watering'),
-            propagation_methods=details.get('propagation_methods'),
-            best_light_condition=details.get('best_light_condition'),
-            best_soil_type=details.get('best_soil_type'),
-            cultural_significance=details.get('cultural_significance'),
-            best_watering=details.get('best_watering'),
-            similar_images=[SimilarImage(url=img.url, similarity=img.similarity)
-                             for img in (s.similar_images or [])]
-        ))
+        if details.get("description"):
+            desc = details["description"].get("value")
+        suggestions.append(
+            Suggestion(
+                id=s.id,
+                name=s.name.title(),
+                probability=s.probability,
+                common_names=[c.title() for c in details.get("common_names")],
+                taxonomy=details.get("taxonomy"),
+                url=details.get("url"),
+                description=desc,
+                synonyms=details.get("synonyms"),
+                edible_parts=details.get("edible_parts"),
+                watering=details.get("watering"),
+                propagation_methods=details.get("propagation_methods"),
+                best_light_condition=details.get("best_light_condition"),
+                best_soil_type=details.get("best_soil_type"),
+                cultural_significance=details.get("cultural_significance"),
+                best_watering=details.get("best_watering"),
+                similar_images=[
+                    SimilarImage(url=img.url, similarity=img.similarity)
+                    for img in (s.similar_images or [])
+                ],
+            )
+        )
 
     response = PlantResponse(
         user_id=user["sub"],
@@ -90,7 +116,8 @@ async def identify_plant(request: IdentifyRequest, user=Depends(get_current_user
         latitude=identification.input.latitude,
         longitude=identification.input.longitude,
         image_data=request.image_data,
-        _ts=int(time.time())
+        organs=request.organs,
+        _ts=int(time.time()),
     )
 
     # Immediately save to MongoDB
@@ -100,27 +127,32 @@ async def identify_plant(request: IdentifyRequest, user=Depends(get_current_user
 
     return response
 
+
 @router.put("/update-plant-notes")
 async def update_plant_notes(request: UpdateNotesRequest):
     if not ObjectId.is_valid(request.id):
         raise HTTPException(status_code=400, detail="Invalid plant ID")
     result = await db.plants.update_one(
         {"_id": ObjectId(request.id)},
-        {"$set": {"notes": request.notes, "_ts": int(time.time())}}
+        {"$set": {"notes": request.notes, "_ts": int(time.time())}},
     )
     if result.matched_count == 0:
         raise HTTPException(status_code=404, detail="Plant not found")
     return {"id": request.id, "notes": request.notes}
+
 
 @router.delete("/delete-plant/{plant_id}")
 async def delete_plant(plant_id: str, user=Depends(get_current_user)):
     """Delete a plant record by id for the current user."""
     if not ObjectId.is_valid(plant_id):
         raise HTTPException(status_code=400, detail="Invalid plant ID")
-    result = await db.plants.delete_one({"_id": ObjectId(plant_id), "user_id": user["sub"]})
+    result = await db.plants.delete_one(
+        {"_id": ObjectId(plant_id), "user_id": user["sub"]}
+    )
     if result.deleted_count == 0:
         raise HTTPException(status_code=404, detail="Plant not found")
     return {"id": plant_id}
+
 
 # --- Fetch Plants ---
 @router.get("/my-plants", response_model=List[PlantResponse])
@@ -133,10 +165,12 @@ async def get_plants(user=Depends(get_current_user)):
         results.append(PlantResponse(**doc))
     return results
 
+
 @router.get("/auth/me")
 async def me(user=Depends(get_current_user)):
     # get_current_user returned the JWT payload with user info
-    return { "email": user["email"], "sub": user["sub"] }
+    return {"email": user["email"], "sub": user["sub"]}
+
 
 @router.post("/auth/logout")
 async def logout():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -7,64 +7,84 @@ os.environ.setdefault("PLANT_ID_API_KEY", "test")
 
 from server.app import routes, main, deps
 
+
 class DummyCursor:
     def __init__(self, docs):
         self._docs = docs
+
     async def to_list(self, length):
         return self._docs[:length]
+
 
 class DummyPlants:
     def __init__(self, docs=None):
         self.docs = docs or []
+
     async def insert_one(self, doc):
         self.docs.append(doc)
         return types.SimpleNamespace(inserted_id="1")
+
     def find(self, query):
         return DummyCursor(self.docs)
+
     async def update_one(self, filter_, update):
         matched = 1 if self.docs else 0
         return types.SimpleNamespace(matched_count=matched)
+
     async def delete_one(self, filter_):
         before = len(self.docs)
-        self.docs = [d for d in self.docs if str(d.get("_id")) != str(filter_.get("_id"))]
+        self.docs = [
+            d for d in self.docs if str(d.get("_id")) != str(filter_.get("_id"))
+        ]
         deleted = before - len(self.docs)
         return types.SimpleNamespace(deleted_count=deleted)
+
     async def create_index(self, *args, **kwargs):
         pass
+
 
 class DummyClientAdmin:
     async def command(self, *args, **kwargs):
         pass
 
+
 class DummyClient:
     def __init__(self):
         self.admin = DummyClientAdmin()
+
 
 class DummyDB:
     def __init__(self, docs=None):
         self.client = DummyClient()
         self.plants = DummyPlants(docs)
 
+
 @pytest.fixture
 def client(monkeypatch):
     fake_db = DummyDB([{"_id": "507f1f77bcf86cd799439011", "user_id": "user1"}])
     monkeypatch.setattr(routes, "db", fake_db)
     monkeypatch.setattr(main, "db", fake_db)
-    main.app.dependency_overrides[deps.get_current_user] = lambda: {"sub": "user1", "email": "test@example.com"}
+    main.app.dependency_overrides[deps.get_current_user] = lambda: {
+        "sub": "user1",
+        "email": "test@example.com",
+    }
     with TestClient(main.app) as c:
         yield c
     main.app.dependency_overrides.clear()
+
 
 def test_auth_me(client):
     resp = client.get("/api/auth/me")
     assert resp.status_code == 200
     assert resp.json() == {"email": "test@example.com", "sub": "user1"}
 
+
 def test_logout(client):
     resp = client.post("/api/auth/logout")
     assert resp.status_code == 200
     assert resp.json()["detail"] == "Logged out"
     assert "access_token=" in resp.headers.get("set-cookie", "")
+
 
 def test_get_plants(client):
     resp = client.get("/api/my-plants")
@@ -74,29 +94,85 @@ def test_get_plants(client):
     if data:
         assert "id" in data[0]
 
+
 def test_update_notes_not_found(client, monkeypatch):
     # patch db to have no docs so update_one returns matched_count=0
     empty_db = DummyDB([])
     monkeypatch.setattr(routes, "db", empty_db)
     monkeypatch.setattr(main, "db", empty_db)
     with TestClient(main.app) as c:
-        main.app.dependency_overrides[deps.get_current_user] = lambda: {"sub": "user1", "email": "test@example.com"}
-        resp = c.put("/api/update-plant-notes", json={"id": "507f1f77bcf86cd799439011", "notes": "hi"})
+        main.app.dependency_overrides[deps.get_current_user] = lambda: {
+            "sub": "user1",
+            "email": "test@example.com",
+        }
+        resp = c.put(
+            "/api/update-plant-notes",
+            json={"id": "507f1f77bcf86cd799439011", "notes": "hi"},
+        )
     main.app.dependency_overrides.clear()
     assert resp.status_code == 404
+
 
 def test_delete_plant(client):
     resp = client.delete("/api/delete-plant/507f1f77bcf86cd799439011")
     assert resp.status_code == 200
     assert resp.json()["id"] == "507f1f77bcf86cd799439011"
 
+
 def test_delete_plant_not_found(client, monkeypatch):
     empty_db = DummyDB([])
     monkeypatch.setattr(routes, "db", empty_db)
     monkeypatch.setattr(main, "db", empty_db)
     with TestClient(main.app) as c:
-        main.app.dependency_overrides[deps.get_current_user] = lambda: {"sub": "user1", "email": "test@example.com"}
+        main.app.dependency_overrides[deps.get_current_user] = lambda: {
+            "sub": "user1",
+            "email": "test@example.com",
+        }
         resp = c.delete("/api/delete-plant/507f1f77bcf86cd799439011")
     main.app.dependency_overrides.clear()
     assert resp.status_code == 404
 
+
+def test_identify_plant_passes_organs(client, monkeypatch):
+    called = {}
+
+    class DummyIdent:
+        def __init__(self):
+            self.status = types.SimpleNamespace(name="COMPLETED")
+            self.access_token = "tok"
+            self.input = types.SimpleNamespace(
+                latitude=0.0, longitude=0.0, datetime="2024-01-01T00:00:00"
+            )
+            sug = types.SimpleNamespace(
+                id="1",
+                name="a",
+                probability=1.0,
+                similar_images=[],
+                details={"common_names": ["a"]},
+            )
+            classification = types.SimpleNamespace(suggestions=[sug])
+            self.result = types.SimpleNamespace(
+                is_plant=types.SimpleNamespace(binary=True, probability=1.0),
+                classification=classification,
+            )
+
+    def dummy_identify(images, **kwargs):
+        called["organs"] = kwargs.get("organs")
+        return DummyIdent()
+
+    monkeypatch.setattr(
+        routes, "plant_client", types.SimpleNamespace(identify=dummy_identify)
+    )
+
+    resp = client.post(
+        "/api/identify-plant",
+        json={
+            "image_data": ["data:image/jpeg;base64,aGVsbG8="],
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "organs": ["leaf"],
+        },
+    )
+
+    assert resp.status_code == 200
+    assert called["organs"] == ["leaf"]


### PR DESCRIPTION
## Summary
- allow IdentifyRequest and PlantResponse to store organs
- forward organs to PlantApi in server routes
- send organs in the frontend API client
- update camera and upload components to choose organ per image
- pass organs from Index page
- test that organs are forwarded to PlantApi

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b9155ba5c83258ec35710acdfb6fd