### PR TITLE
Switch identify route to multipart file uploads

### DIFF
--- a/plant-tracker-client/src/components/ImageUpload.tsx
+++ b/plant-tracker-client/src/components/ImageUpload.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from '@/hooks/use-toast';
 
 interface ImageUploadProps {
-  onUpload: (images: { image: string; organ: string }[]) => void;
+  onUpload: (images: { file: File; organ: string }[]) => void;
   onBack: () => void;
   identifying?: boolean;
 }
@@ -21,7 +21,7 @@ interface ImageUploadProps {
 const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
-  const [previews, setPreviews] = useState<{ image: string; organ: string }[]>([]);
+  const [previews, setPreviews] = useState<{ file: File; preview: string; organ: string }[]>([]);
 
   const handleFile = (file: File) => {
     if (previews.length >= 5) {
@@ -36,7 +36,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying
     const reader = new FileReader();
     reader.onload = (e) => {
       const imageData = e.target?.result as string;
-      setPreviews(prev => [...prev, { image: imageData, organ: 'auto' }]);
+      setPreviews(prev => [...prev, { file, preview: imageData, organ: 'auto' }]);
     };
     reader.readAsDataURL(file);
   };
@@ -69,7 +69,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying
 
   const handleUpload = () => {
     if (previews.length) {
-      onUpload(previews);
+      onUpload(previews.map(p => ({ file: p.file, organ: p.organ })));
     }
   };
 
@@ -156,7 +156,7 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ onUpload, onBack, identifying
               {previews.map((p, idx) => (
                 <div key={idx} className="relative space-y-2">
                   <img
-                    src={p.image}
+                    src={p.preview}
                     alt={`preview-${idx}`}
                     className="w-full h-40 object-cover rounded-lg"
                   />

--- a/plant-tracker-client/src/components/PlantCamera.tsx
+++ b/plant-tracker-client/src/components/PlantCamera.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from '@/hooks/use-toast';
 
 interface PlantCameraProps {
-  onCapture: (images: { image: string; organ: string }[]) => void;
+  onCapture: (images: { file: File; organ: string }[]) => void;
   onBack: () => void;
   identifying?: boolean;
 }
@@ -25,7 +25,7 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [facingMode, setFacingMode] = useState<'user' | 'environment'>('environment');
-  const [captures, setCaptures] = useState<{ image: string; organ: string }[]>([]);
+  const [captures, setCaptures] = useState<{ file: File; preview: string; organ: string }[]>([]);
 
   useEffect(() => {
     startCamera();
@@ -78,8 +78,12 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
     canvas.height = video.videoHeight;
     context.drawImage(video, 0, 0);
 
-    const imageData = canvas.toDataURL('image/jpeg', 0.8);
-    setCaptures(prev => [...prev, { image: imageData, organ: 'auto' }]);
+    const preview = canvas.toDataURL('image/jpeg', 0.8);
+    canvas.toBlob(blob => {
+      if (!blob) return;
+      const file = new File([blob], `capture-${Date.now()}.jpg`, { type: 'image/jpeg' });
+      setCaptures(prev => [...prev, { file, preview, organ: 'auto' }]);
+    }, 'image/jpeg', 0.8);
   };
 
   const switchCamera = () => {
@@ -159,7 +163,7 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
               {captures.map((cap, idx) => (
                 <div key={idx} className="relative space-y-2">
-                <img src={cap.image} alt={`capture-${idx}`} className="w-full h-32 object-cover rounded-lg" />
+                <img src={cap.preview} alt={`capture-${idx}`} className="w-full h-32 object-cover rounded-lg" />
                 <div className="flex items-center space-x-2">
                   <Select value={cap.organ} onValueChange={val => setCaptures(c => c.map((p,i)=> i===idx ? { ...p, organ: val } : p))}>
                     <SelectTrigger className="w-full">
@@ -188,7 +192,7 @@ const PlantCamera: React.FC<PlantCameraProps> = ({ onCapture, onBack, identifyin
             <Button onClick={() => setCaptures([])} variant="outline">
               Clear All
             </Button>
-            <Button onClick={() => onCapture(captures)} disabled={captures.length === 0} className="bg-green-600 hover:bg-green-700">
+            <Button onClick={() => onCapture(captures.map(c => ({ file: c.file, organ: c.organ })))} disabled={captures.length === 0} className="bg-green-600 hover:bg-green-700">
               Identify Plant
             </Button>
           </div>

--- a/plant-tracker-client/src/pages/Index.tsx
+++ b/plant-tracker-client/src/pages/Index.tsx
@@ -72,15 +72,13 @@ const Index = () => {
     })();
   }, [user]);
 
-  const handleImageCapture = async (images: { image: string; organ: string }[]) => {
+  const handleImageCapture = async (images: { file: File; organ: string }[]) => {
     setIdentifying(true);
     try {
       const resp = await identifyPlant(
-        images.map(i => i.image),
+        images.map(i => i.file),
         latitude ?? undefined,
         longitude ?? undefined,
-        undefined,
-        undefined,
         images.map(i => i.organ)
       );
 

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -3,14 +3,6 @@ from typing import List, Optional, Dict, Any
 
 
 # --- Pydantic Models ---
-class IdentifyRequest(BaseModel):
-    user_id: Optional[str] = None
-    image_data: List[str]  # up to 5 base64-encoded images
-    latitude: float
-    longitude: float
-    organs: Optional[List[str]] = None
-
-
 class SimilarImage(BaseModel):
     url: HttpUrl
     similarity: float

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -166,12 +166,8 @@ def test_identify_plant_passes_organs(client, monkeypatch):
 
     resp = client.post(
         "/api/identify-plant",
-        json={
-            "image_data": ["data:image/jpeg;base64,aGVsbG8="],
-            "latitude": 0.0,
-            "longitude": 0.0,
-            "organs": ["leaf"],
-        },
+        files=[("files", ("img.jpg", b"hello", "image/jpeg"))],
+        data={"latitude": "0.0", "longitude": "0.0", "organs": "leaf"},
     )
 
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow uploading image files instead of base64
- adjust API client and frontend components to send multipart data
- remove unused IdentifyRequest model
- update tests for new API signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b963dc6b08325901be0ac1e354268