### PR TITLE
Add user persistence and auth integration

### DIFF
--- a/server/app/deps.py
+++ b/server/app/deps.py
@@ -4,20 +4,21 @@ from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import jwt
 
+from .services.database import get_user_by_sub
+
 oauth2_scheme = HTTPBearer(auto_error=False)
 
 async def get_current_user(request: Request):
-    """Return JWT payload from header or cookie."""
+    """Retrieve the current user document from the database."""
     credentials: HTTPAuthorizationCredentials | None = await oauth2_scheme(request)
-    token = None
-    if credentials:
-        token = credentials.credentials
-    else:
-        token = request.cookies.get("access_token")
+    token = credentials.credentials if credentials else request.cookies.get("access_token")
     if not token:
         raise HTTPException(401, "Invalid auth token")
     try:
         payload = jwt.decode(token, settings.jwt_secret, algorithms=["HS256"])
     except jwt.PyJWTError:
         raise HTTPException(401, "Invalid auth token")
-    return payload  # e.g. { sub, email, exp }
+    user = await get_user_by_sub(payload.get("sub"))
+    if not user:
+        raise HTTPException(401, "User not found")
+    return user

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -18,8 +18,9 @@ async def lifespan(app: FastAPI):
     # --- Startup code ---
     # 1) Warm up the driver / open pool & auth
     await db.client.admin.command("ping")
-    # 2) Create index on user_id for fast lookups
+    # 2) Create indexes for fast lookups
     await db.plants.create_index("user_id", name="idx_user_id")
+    await db.users.create_index("sub", unique=True, name="idx_users_sub")
     yield
     # --- (optional) Shutdown code could go here ---
 

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel, HttpUrl
 from typing import List, Optional, Dict, Any
 
@@ -24,6 +25,16 @@ class Suggestion(BaseModel):
     cultural_significance: Optional[str] = None
     best_watering: Optional[str] = None
     similar_images: Optional[List[SimilarImage]] = []
+
+
+class User(BaseModel):
+    id: Optional[str] = None
+    sub: str
+    email: str
+    name: Optional[str] = None
+    picture: Optional[HttpUrl] = None
+    tier: Optional[str] = None
+    created_at: Optional[datetime] = None
 
 
 class PlantResponse(BaseModel):

--- a/server/app/routers/auth.py
+++ b/server/app/routers/auth.py
@@ -5,6 +5,7 @@ from authlib.integrations.starlette_client import OAuth, OAuthError
 
 from ..config import settings
 from ..deps import get_current_user
+from ..services.database import upsert_user
 
 router = APIRouter(prefix="/api/auth")
 
@@ -36,20 +37,16 @@ async def auth_callback(request: Request):
     # user_info = await oauth.google.parse_id_token(request, token)
     resp = await oauth.google.get('https://openidconnect.googleapis.com/v1/userinfo', token=token)
     user_info = resp.json()
-    # user_info contains keys like: sub, email, name, picture, ...
-    # Now you can upsert this user into Mongo and issue your own JWT / session cookie
+    stored_user = await upsert_user(user_info)
 
-    # e.g.:
-    # db.users.update_one({ "google_id": user_info["sub"] }, { "$set": {...} }, upsert=True)
-    #
-    # Then create your own signed token (JWT) to send back:
     from fastapi import Response
     import jwt, time
 
     payload = {
-        "sub": user_info["sub"],
-        "email": user_info["email"],
-        "exp": time.time() + 3600
+        "sub": stored_user["sub"],
+        "email": stored_user.get("email"),
+        "tier": stored_user.get("tier"),
+        "exp": time.time() + 3600,
     }
     jwt_token = jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
 

--- a/server/app/services/database.py
+++ b/server/app/services/database.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from fastapi.encoders import jsonable_encoder
 from pymongo.server_api import ServerApi
 import motor.motor_asyncio
+from typing import Optional, Dict, Any
 
 from ..config import settings
 from ..models import PlantResponse
@@ -18,3 +20,34 @@ async def save_to_db(response: PlantResponse) -> PlantResponse:
     result = await db.plants.insert_one(doc)
     response.id = str(result.inserted_id)
     return response
+
+
+async def upsert_user(user_info: Dict[str, Any]) -> Dict[str, Any]:
+    """Insert or update a user document in the database."""
+    data = {
+        "sub": user_info["sub"],
+        "email": user_info.get("email"),
+        "name": user_info.get("name"),
+        "picture": user_info.get("picture"),
+        "tier": user_info.get("tier", "free"),
+    }
+    await db.users.update_one(
+        {"sub": data["sub"]},
+        {
+            "$set": {k: v for k, v in data.items() if v is not None},
+            "$setOnInsert": {"created_at": datetime.utcnow()},
+        },
+        upsert=True,
+    )
+    doc = await db.users.find_one({"sub": data["sub"]})
+    doc["id"] = str(doc.pop("_id"))
+    return doc
+
+
+async def get_user_by_sub(sub: str) -> Optional[Dict[str, Any]]:
+    """Fetch a user document by its subject identifier."""
+    doc = await db.users.find_one({"sub": sub})
+    if doc:
+        doc["id"] = str(doc.pop("_id"))
+        return doc
+    return None

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -44,6 +44,11 @@ class DummyPlants:
         pass
 
 
+class DummyUsers:
+    async def create_index(self, *args, **kwargs):
+        pass
+
+
 class DummyClientAdmin:
     async def command(self, *args, **kwargs):
         pass
@@ -58,6 +63,7 @@ class DummyDB:
     def __init__(self, docs=None):
         self.client = DummyClient()
         self.plants = DummyPlants(docs)
+        self.users = DummyUsers()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- define a User pydantic model
- add database helpers for storing and fetching users
- index users by `sub`, upsert users on auth callback, and fetch current user from DB

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e0fe763083258f11c3fc52f96dcc